### PR TITLE
motype option specified when parsing data from gamess

### DIFF
--- a/src/converters/convert_from.py
+++ b/src/converters/convert_from.py
@@ -24,7 +24,7 @@ except:
 
 
 
-def run_resultsFile(trexio_filename, filename, motype, back_end):
+def run_resultsFile(trexio_filename, filename, back_end, motype=None):
 
     if os.path.exists(filename):
         os.system("rm -rf -- "+trexio_filename)
@@ -288,7 +288,7 @@ def run_resultsFile(trexio_filename, filename, motype, back_end):
     if motype is None:
         MO_type = res.determinants_mo_type
     else:
-        MO_type = motype.upper()
+        MO_type = motype
 
     allMOs = res.mo_sets[MO_type]
     trexio.write_mo_type(trexio_file, MO_type)
@@ -418,11 +418,11 @@ def run_resultsFile(trexio_filename, filename, motype, back_end):
     return
 
 
-def run(trexio_filename, filename, filetype,  motype, back_end):
+def run(trexio_filename, filename, filetype, back_end, motype=None):
     if filetype.lower() == "gaussian":
         run_resultsFile(trexio_filename, filename, back_end)
     elif filetype.lower() == "gamess":
-        run_resultsFile(trexio_filename, filename, motype, back_end)
+        run_resultsFile(trexio_filename, filename, back_end, motype)
     elif filetype.lower() == "fcidump":
         run_fcidump(trexio_filename, filename, back_end)
     elif filetype.lower() == "molden":

--- a/src/converters/convert_from.py
+++ b/src/converters/convert_from.py
@@ -24,7 +24,7 @@ except:
 
 
 
-def run_resultsFile(trexio_filename, filename, back_end):
+def run_resultsFile(trexio_filename, filename, motype, back_end):
 
     if os.path.exists(filename):
         os.system("rm -rf -- "+trexio_filename)
@@ -215,7 +215,7 @@ def run_resultsFile(trexio_filename, filename, back_end):
     trexio.write_basis_nucleus_index(trexio_file,nucleus_index_per_shell)
     trexio.write_basis_shell_ang_mom(trexio_file,shell_ang_mom)
     trexio.write_basis_shell_index(trexio_file,shell_index_per_prim)
-    
+
     # write normalization factor for each shell
     trexio.write_basis_shell_factor(trexio_file,shell_factor)
 
@@ -285,31 +285,23 @@ def run_resultsFile(trexio_filename, filename, back_end):
     # MOs
     # ---
 
-    MoTag = res.determinants_mo_type
-    MO_type = MoTag
-    allMOs = res.mo_sets[MO_type]
+    if motype is None:
+        MO_type = res.determinants_mo_type
+    else:
+        MO_type = motype.upper()
 
+    allMOs = res.mo_sets[MO_type]
     trexio.write_mo_type(trexio_file, MO_type)
 
-    try:
-        closed  = [(allMOs[i].eigenvalue, i) for i in res.closed_mos]
-        virtual = [(allMOs[i].eigenvalue, i) for i in res.virtual_mos]
-        active  = [(allMOs[i].eigenvalue, i) for i in res.active_mos]
-    except:
-        closed  = []
-        virtual = []
-        active  = [(allMOs[i].eigenvalue, i) for i in range(len(allMOs))]
+    full_mo_set  = [(allMOs[i].eigenvalue, i) for i in range(len(allMOs))]
 
-    closed  = [x[1] for x in closed]
-    active  = [x[1] for x in active]
-    virtual = [x[1] for x in virtual]
-    MOindices = closed + active + virtual
+    MOindices = [x[1] for x in full_mo_set]
 
     MOs = []
     for i in MOindices:
         MOs.append(allMOs[i])
 
-    mo_num = len(MOs)
+    mo_num = len(MOindices)
     while len(MOindices) < mo_num:
         MOindices.append(len(MOindices))
 
@@ -426,11 +418,11 @@ def run_resultsFile(trexio_filename, filename, back_end):
     return
 
 
-def run(trexio_filename, filename, filetype, back_end):
+def run(trexio_filename, filename, filetype,  motype, back_end):
     if filetype.lower() == "gaussian":
         run_resultsFile(trexio_filename, filename, back_end)
     elif filetype.lower() == "gamess":
-        run_resultsFile(trexio_filename, filename, back_end)
+        run_resultsFile(trexio_filename, filename, motype, back_end)
     elif filetype.lower() == "fcidump":
         run_fcidump(trexio_filename, filename, back_end)
     elif filetype.lower() == "molden":

--- a/src/converters/convert_from.py
+++ b/src/converters/convert_from.py
@@ -294,8 +294,22 @@ def run_resultsFile(trexio_filename, filename, back_end, motype=None):
     trexio.write_mo_type(trexio_file, MO_type)
 
     full_mo_set  = [(allMOs[i].eigenvalue, i) for i in range(len(allMOs))]
-
     MOindices = [x[1] for x in full_mo_set]
+
+    ## The following commented portion for the future use.
+    # try:
+    #     closed  = [(allMOs[i].eigenvalue, i) for i in res.closed_mos]
+    #     virtual = [(allMOs[i].eigenvalue, i) for i in res.virtual_mos]
+    #     active  = [(allMOs[i].eigenvalue, i) for i in res.active_mos]
+    # except:
+    #     closed  = []
+    #     virtual = []
+    #     active  = [(allMOs[i].eigenvalue, i) for i in range(len(allMOs))]
+
+    # closed  = [x[1] for x in closed]
+    # active  = [x[1] for x in active]
+    # virtual = [x[1] for x in virtual]
+    # MOindices = closed + active + virtual
 
     MOs = []
     for i in MOindices:

--- a/src/converters/trex2champ.py
+++ b/src/converters/trex2champ.py
@@ -59,15 +59,14 @@ except:
     sys.exit(1)
 
 try:
-    sys.path.append('/home/ravindra/trial/resultsFile')
     import resultsFile
 except:
     print("Error: The resultsFile Python library is not installed")
     sys.exit(1)
 
-def run(filename,  gamessfile, back_end=trexio.TREXIO_HDF5):
+def run(filename,  gamessfile, motype, back_end):
 
-    trexio_file = trexio.File(filename, mode='r',back_end=trexio.TREXIO_HDF5)
+    trexio_file = trexio.File(filename, mode='r',back_end=back_end)
 
 
     # Metadata
@@ -167,7 +166,7 @@ def run(filename,  gamessfile, back_end=trexio.TREXIO_HDF5):
     write_champ_file_determinants(filename, file)
 
     # Write the eigenvalues for a given type of orbitals using the resultsFile package
-    write_champ_file_eigenvalues(filename, file, "GUGA")
+    write_champ_file_eigenvalues(filename, file, dict_mo["type"])
 
     return
 

--- a/src/converters/trex2champ.py
+++ b/src/converters/trex2champ.py
@@ -64,7 +64,7 @@ except:
     print("Error: The resultsFile Python library is not installed")
     sys.exit(1)
 
-def run(filename,  gamessfile, motype, back_end):
+def run(filename,  gamessfile, back_end, motype=None):
 
     trexio_file = trexio.File(filename, mode='r',back_end=back_end)
 

--- a/src/trexio_tools/trexio_run.py
+++ b/src/trexio_tools/trexio_run.py
@@ -3,19 +3,19 @@
 Set of tools to interact with trexio files.
 
 Usage:
-      trexio check-basis   [-n n_points]           [-b back_end]  TREXIO_FILE          
-      trexio check-mos     [-n n_points]           [-b back_end]  TREXIO_FILE          
-      trexio convert2champ  -i input_file          [-b back_end]  TREXIO_FILE 
-      trexio convert-from   -t type -i input_file  [-b back_end]  TREXIO_FILE 
-      trexio convert-to     -t type -o output_file                TREXIO_FILE 
+      trexio check-basis   [-n n_points]            [-b back_end]  TREXIO_FILE
+      trexio check-mos     [-n n_points]            [-b back_end]  TREXIO_FILE
+      trexio convert-to     -t type -o output_file                 TREXIO_FILE
+      trexio convert2champ  -i GAMESS_input_file  -x orbital_type  [-b back_end]  TREXIO_FILE
+      trexio convert-from   -t type -i input_file -x orbital_type [-b back_end]  TREXIO_FILE
 
 Options:
       -n --n_points=n              Number of integration points. Default is 81.
-      -i --input=input_file        Name of the input file 
-      -o --output=output_file      Name of the output file 
+      -i --input=input_file        Name of the input file
+      -o --output=output_file      Name of the output file
       -b --back_end=[hdf5 | text]  The TREXIO back end. Default is hdf5.
-      -t --type=[gaussian | gamess | fcidump | molden | champ | cartesian | spherical ]
-                                   File format
+      -t --type=[gaussian | gamess | fcidump | molden | champ | cartesian | spherical ] File format
+      -x --motype=[natural | initial | guga-initial | guga-natural]  The type of the molecular orbitals. Default is natural.
 """
 
 from docopt import docopt
@@ -46,6 +46,11 @@ def main(filename=None, args=None):
     else:
         back_end = trexio.TREXIO_HDF5
 
+    if args["--motype"] is not None:
+        motype = str(args["--motype"]).upper()
+    else:
+        motype = 'NATURAL'
+
 
     if args["check-basis"]:
         trexio_file = trexio.File(filename, 'r', back_end=back_end)
@@ -65,11 +70,12 @@ def main(filename=None, args=None):
 
     elif args["convert2champ"]:
         from converters.trex2champ import run
-        run(filename, gamessfile = args["--input"], back_end=back_end)
+        import pprint; pprint.pprint(args)
+        run(filename, gamessfile = args["--input"], motype=motype, back_end=back_end)
 
     elif args["convert-from"]:
         from converters.convert_from import run
-        run(args["TREXIO_FILE"], args["--input"], args["--type"], back_end=back_end)
+        run(args["TREXIO_FILE"], args["--input"], args["--type"], motype=motype, back_end=back_end)
 
     elif args["convert-to"]:
         from converters.convert_to import run
@@ -82,6 +88,7 @@ def main(filename=None, args=None):
 
 if __name__ == '__main__':
     args = docopt(__doc__)
+    import pprint; pprint.pprint(args)
     filename = args["TREXIO_FILE"]
     main(filename, args)
 

--- a/src/trexio_tools/trexio_run.py
+++ b/src/trexio_tools/trexio_run.py
@@ -46,11 +46,6 @@ def main(filename=None, args=None):
     else:
         back_end = trexio.TREXIO_HDF5
 
-    if args["--motype"] is not None:
-        motype = str(args["--motype"])
-    else:
-        motype = None
-
 
     if args["check-basis"]:
         trexio_file = trexio.File(filename, 'r', back_end=back_end)
@@ -70,11 +65,11 @@ def main(filename=None, args=None):
 
     elif args["convert2champ"]:
         from converters.trex2champ import run
-        run(filename, gamessfile = args["--input"], back_end=back_end, motype=motype)
+        run(filename, gamessfile = args["--input"], back_end=back_end, motype=args["--motype"])
 
     elif args["convert-from"]:
         from converters.convert_from import run
-        run(args["TREXIO_FILE"], args["--input"], args["--type"], back_end=back_end, motype=motype)
+        run(args["TREXIO_FILE"], args["--input"], args["--type"], back_end=back_end, motype=args["--motype"])
 
     elif args["convert-to"]:
         from converters.convert_to import run

--- a/src/trexio_tools/trexio_run.py
+++ b/src/trexio_tools/trexio_run.py
@@ -6,8 +6,8 @@ Usage:
       trexio check-basis   [-n n_points]            [-b back_end]  TREXIO_FILE
       trexio check-mos     [-n n_points]            [-b back_end]  TREXIO_FILE
       trexio convert-to     -t type -o output_file                 TREXIO_FILE
-      trexio convert2champ  -i GAMESS_input_file  -x orbital_type  [-b back_end]  TREXIO_FILE
-      trexio convert-from   -t type -i input_file -x orbital_type [-b back_end]  TREXIO_FILE
+      trexio convert2champ  -i GAMESS_input_file  [-x orbital_type]  [-b back_end]  TREXIO_FILE
+      trexio convert-from   -t type -i input_file [-x orbital_type] [-b back_end]  TREXIO_FILE
 
 Options:
       -n --n_points=n              Number of integration points. Default is 81.
@@ -47,9 +47,9 @@ def main(filename=None, args=None):
         back_end = trexio.TREXIO_HDF5
 
     if args["--motype"] is not None:
-        motype = str(args["--motype"]).upper()
+        motype = str(args["--motype"])
     else:
-        motype = 'NATURAL'
+        motype = None
 
 
     if args["check-basis"]:
@@ -70,12 +70,11 @@ def main(filename=None, args=None):
 
     elif args["convert2champ"]:
         from converters.trex2champ import run
-        import pprint; pprint.pprint(args)
-        run(filename, gamessfile = args["--input"], motype=motype, back_end=back_end)
+        run(filename, gamessfile = args["--input"], back_end=back_end, motype=motype)
 
     elif args["convert-from"]:
         from converters.convert_from import run
-        run(args["TREXIO_FILE"], args["--input"], args["--type"], motype=motype, back_end=back_end)
+        run(args["TREXIO_FILE"], args["--input"], args["--type"], back_end=back_end, motype=motype)
 
     elif args["convert-to"]:
         from converters.convert_to import run
@@ -88,7 +87,6 @@ def main(filename=None, args=None):
 
 if __name__ == '__main__':
     args = docopt(__doc__)
-    import pprint; pprint.pprint(args)
     filename = args["TREXIO_FILE"]
     main(filename, args)
 


### PR DESCRIPTION
Hi!,
When using the convert-from tool, I needed to choose the type of molecular orbitals to be written into the hdf5 file. I have created a command-line option for that. 
Also, all the available MOs are read for that given type (the split-up of closed + virtual + active) is replaced by a loop over all the MOs.
