### PR TITLE
Fix check-basis and check-mos

### DIFF
--- a/src/group_tools/ao.py
+++ b/src/group_tools/ao.py
@@ -7,10 +7,11 @@ from . import basis as trexio_basis
 def read(trexio_file):
     r = {}
 
-    r["basis"]  = trexio_basis.read(trexio_file)
-    r["num"]    = trexio.read_ao_num(trexio_file)
-    r["shell"]  = trexio.read_ao_shell(trexio_file)
-    r["factor"] = trexio.read_ao_normalization(trexio_file)
+    r["basis"]     = trexio_basis.read(trexio_file)
+    r["basis_old"] = trexio_basis.convert_to_old(r["basis"])
+    r["num"]       = trexio.read_ao_num(trexio_file)
+    r["shell"]     = trexio.read_ao_shell(trexio_file)
+    r["factor"]    = trexio.read_ao_normalization(trexio_file)
 
     return r
 
@@ -28,18 +29,22 @@ def value(ao,r):
     Evaluates all the basis functions at R=(x,y,z)
     """
 
-    basis              =  ao["basis"]
-    nucleus            =  basis["nucleus"]
-    coord              =  nucleus["coord"]
-    nucleus_num        =  nucleus["num"]
+    basis          =  ao["basis"]
 
-    basis_num          =  basis["num"]
-    prim_num           =  basis["prim_num"]
-    nucleus_shell_num  =  basis["nucleus_shell_num"]
-    nucleus_index      =  basis["nucleus_index"]
-    shell_ang_mom      =  basis["shell_ang_mom"]
-    shell_prim_num     =  basis["shell_prim_num"]
-    shell_prim_index   =  basis["shell_prim_index"]
+    nucleus        =  basis["nucleus"]
+    coord          =  nucleus["coord"]
+    nucleus_num    =  nucleus["num"]
+
+    basis_num      =  basis["shell_num"]
+    prim_num       =  basis["prim_num"]
+    shell_ang_mom  =  basis["shell_ang_mom"]
+
+    # to reconstruct for compatibility with TREXIO < v.2.0.0
+    basis_old         = ao["basis_old"]
+    nucleus_index     = basis_old["nucleus_index"]
+    nucleus_shell_num = basis_old["nucleus_shell_num"]
+    shell_prim_index  = basis_old["shell_prim_index"]
+    shell_prim_num    = basis_old["shell_prim_num"]
 
     coefficient = basis["coefficient"] * basis["prim_factor"]
     exponent    = basis["exponent"]

--- a/src/group_tools/basis.py
+++ b/src/group_tools/basis.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from typing import Dict, Tuple
 import trexio
 import numpy as np
 from . import nucleus
@@ -10,18 +11,63 @@ def read(trexio_file):
     r["nucleus"]            =  nucleus.read(trexio_file)
 
     r["type"]               =  trexio.read_basis_type(trexio_file)
-    r["num"]                =  trexio.read_basis_num(trexio_file)
+    r["shell_num"]          =  trexio.read_basis_shell_num(trexio_file)
     r["prim_num"]           =  trexio.read_basis_prim_num(trexio_file)
     r["nucleus_index"]      =  trexio.read_basis_nucleus_index(trexio_file)
-    r["nucleus_shell_num"]  =  trexio.read_basis_nucleus_shell_num(trexio_file)
     r["shell_ang_mom"]      =  trexio.read_basis_shell_ang_mom(trexio_file)
-    r["shell_prim_num"]     =  trexio.read_basis_shell_prim_num(trexio_file)
     r["shell_factor"]       =  trexio.read_basis_shell_factor(trexio_file)
-    r["shell_prim_index"]   =  trexio.read_basis_shell_prim_index(trexio_file)
+    r["shell_index"]        =  trexio.read_basis_shell_index(trexio_file)
     r["exponent"]           =  trexio.read_basis_exponent(trexio_file)
     r["coefficient"]        =  trexio.read_basis_coefficient(trexio_file)
     r["prim_factor"]        =  trexio.read_basis_prim_factor(trexio_file)
 
     return r
 
+
+def convert_to_old(basis: dict) -> Dict:
+    """Convert the new basis set format into the old one (<2.0.0)."""
+
+    basis_old = {}
+    # The quantities below did not change in v.2.0.0
+    basis_old["type"]               =  basis["type"]
+    basis_old["prim_num"]           =  basis["prim_num"]  
+    basis_old["shell_ang_mom"]      =  basis["shell_ang_mom"]
+    basis_old["shell_factor"]       =  basis["shell_factor"]
+    basis_old["exponent"]           =  basis["exponent"]
+    basis_old["coefficient"]        =  basis["coefficient"]
+    basis_old["prim_factor"]        =  basis["prim_factor"] 
+    # basis_num has been renamed into basis_shell_num
+    basis_old["num"]                =  basis["shell_num"]
+    # The per-nucleus and per-shell quantities below have to be reconstructed from the 
+    # `nucleus_index` and `shell_index` maps, respectively, introduced in v.2.0.0
+
+    # Save the data (index of the first shell and No of shells per atom) in the old format
+    l1, l2 = map_to_lists(basis["nucleus_index"], basis["nucleus"]["num"])
+    basis_old["nucleus_index"] = l1 
+    basis_old["nucleus_shell_num"] = l2
+    # Same for primitives per shell
+    l3, l4 = map_to_lists(basis["shell_index"], basis["shell_num"])
+    basis_old["shell_prim_index"] = l3 
+    basis_old["shell_prim_num"] = l4
+
+    return basis_old
+
+
+def map_to_lists(map: list, dim: int) -> tuple:
+    """Convert long map into two short ones (with index and number of elements per instance (e.g. atom), respectively)."""
+    from collections import Counter
+
+    index_per_instance = []
+    instances_done = []
+    for ind, inst in enumerate(map):
+        if not inst in instances_done:
+            index_per_instance.append(ind)
+            instances_done.append(inst)
+
+    n_per_instance = Counter(map)
+    num_per_instance = [ n_per_instance[i] for i in range(dim) ]
+
+    print(map, "\n", index_per_instance, "\n", num_per_instance)
+
+    return (index_per_instance, num_per_instance)
 

--- a/src/group_tools/basis.py
+++ b/src/group_tools/basis.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from typing import Dict, Tuple
 import trexio
 import numpy as np
 from . import nucleus
@@ -24,7 +23,7 @@ def read(trexio_file):
     return r
 
 
-def convert_to_old(basis: dict) -> Dict:
+def convert_to_old(basis: dict) -> dict:
     """Convert the new basis set format into the old one (<2.0.0)."""
 
     basis_old = {}
@@ -38,10 +37,9 @@ def convert_to_old(basis: dict) -> Dict:
     basis_old["prim_factor"]        =  basis["prim_factor"] 
     # basis_num has been renamed into basis_shell_num
     basis_old["num"]                =  basis["shell_num"]
-    # The per-nucleus and per-shell quantities below have to be reconstructed from the 
+    # The per-nucleus and per-shell lists below have to be reconstructed from the 
     # `nucleus_index` and `shell_index` maps, respectively, introduced in v.2.0.0
-
-    # Save the data (index of the first shell and No of shells per atom) in the old format
+    # Save the data in the old format (index of the first shell and No of shells per atom)
     l1, l2 = map_to_lists(basis["nucleus_index"], basis["nucleus"]["num"])
     basis_old["nucleus_index"] = l1 
     basis_old["nucleus_shell_num"] = l2
@@ -50,24 +48,37 @@ def convert_to_old(basis: dict) -> Dict:
     basis_old["shell_prim_index"] = l3 
     basis_old["shell_prim_num"] = l4
 
+    lists_to_map(l1,l2)
+
     return basis_old
 
 
 def map_to_lists(map: list, dim: int) -> tuple:
     """Convert long map into two short ones (with index and number of elements per instance (e.g. atom), respectively)."""
+
     from collections import Counter
 
     index_per_instance = []
     instances_done = []
-    for ind, inst in enumerate(map):
+    for i, inst in enumerate(map):
         if not inst in instances_done:
-            index_per_instance.append(ind)
+            index_per_instance.append(i)
             instances_done.append(inst)
 
     n_per_instance = Counter(map)
-    num_per_instance = [ n_per_instance[i] for i in range(dim) ]
-
-    print(map, "\n", index_per_instance, "\n", num_per_instance)
+    num_per_instance = [ n_per_instance[j] for j in range(dim) ]
+    #print(map, "\n", index_per_instance, "\n", num_per_instance)
 
     return (index_per_instance, num_per_instance)
 
+
+def lists_to_map(indices: list, numbers: list) -> list:
+    """Convert two lists (with index and number of elements per instance like atom) into one big mapping list."""
+
+    map = []
+    for i, _ in enumerate(indices):
+        for _ in range(numbers[i]):
+            map.append(i)
+    #print(indices, "\n", numbers, "\n", map)
+
+    return map

--- a/src/group_tools/basis.py
+++ b/src/group_tools/basis.py
@@ -48,8 +48,6 @@ def convert_to_old(basis: dict) -> dict:
     basis_old["shell_prim_index"] = l3 
     basis_old["shell_prim_num"] = l4
 
-    lists_to_map(l1,l2)
-
     return basis_old
 
 

--- a/src/group_tools/check_basis.py
+++ b/src/group_tools/check_basis.py
@@ -25,7 +25,8 @@ def run(trexio_file, n_points):
     step = [ None for i in range(3) ]
     for a in range(3):
       linspace[a], step[a] = np.linspace(rmin[a]-shift[a], rmax[a]+shift[a], num=n_points, retstep=True)
-    print (step)
+      
+    print("Integration steps:", step)
     dv = step[0]*step[1]*step[2]
 
     S = np.zeros( [ ao["num"], ao["num"]] )
@@ -40,9 +41,10 @@ def run(trexio_file, n_points):
     ao_num = ao["num"]
     S_ex = trexio.read_ao_1e_int_overlap(trexio_file)
     S_diff = S - S_ex
-    print ("Norm of the error: %f"%(np.linalg.norm(S_diff)))
-    print(S_diff)
+    print("Norm of the error: %f"%(np.linalg.norm(S_diff)))
+    #print(S_diff)
 
+    # This produces a lot of output for large molecules, maybe wrap up in ``if debug`` statement ?
     for i in range(ao_num):
       for j in range(i,ao_num):
         print("%3d %3d %15f %15f"%(i,j,S[i][j],S_ex[i,j]))

--- a/src/group_tools/check_basis.py
+++ b/src/group_tools/check_basis.py
@@ -30,7 +30,7 @@ def run(trexio_file, n_points):
 
     S = np.zeros( [ ao["num"], ao["num"]] )
     for x in linspace[0]:
-      print(".",end='',flush=True)
+      #print(".",end='',flush=True)
       for y in linspace[1]:
         for z in linspace[2]:
            chi = trexio_ao.value(ao, np.array( [x,y,z] ) )

--- a/src/group_tools/check_mos.py
+++ b/src/group_tools/check_mos.py
@@ -27,13 +27,14 @@ def run(trexio_file, n_points):
     step = [ None for i in range(3) ]
     for a in range(3):
       linspace[a], step[a] = np.linspace(rmin[a]-shift[a], rmax[a]+shift[a], num=n_points, retstep=True)
-    print (step)
+
+    print("Integration steps:", step)
     dv = step[0]*step[1]*step[2]
 
     mo_num = mo["num"]
     S = np.zeros( [ mo_num, mo_num ] )
     for x in linspace[0]:
-      print(".",end='',flush=True)
+      #print(".",end='',flush=True)
       for y in linspace[1]:
         for z in linspace[2]:
            chi = trexio_mo.value(mo, np.array( [x,y,z] ) )
@@ -43,7 +44,7 @@ def run(trexio_file, n_points):
     S_ex = np.eye(mo_num)
     S_diff = S - S_ex
     print ("Norm of the error: %f"%(np.linalg.norm(S_diff)))
-    print(S_diff)
+    #print(S_diff)
 
     for i in range(mo_num):
       for j in range(i,mo_num):

--- a/src/group_tools/mo.py
+++ b/src/group_tools/mo.py
@@ -13,13 +13,10 @@ def read(trexio_file):
 
 #    if trexio.has_mo_type(trexio_file):
 #        r["type"]   = trexio.read_mo_type(trexio_file)
-
 #    if trexio.has_mo_class(trexio_file):
 #        r["class"]   = trexio.read_mo_class(trexio_file)
-#
 #    if trexio.has_mo_symmetry(trexio_file):
 #        r["symmetry"]   = trexio.read_mo_symmetry(trexio_file)
-#
 #    if trexio.has_mo_occupation(trexio_file):
 #        r["occupation"]   = trexio.read_mo_occupation(trexio_file)
 


### PR DESCRIPTION
Both functionalities have been broken due to the changes in the basis set format introduced in TREXIO `v.2.0.0`. The basis set components have to be adapted to the previous format in order for the numerical benchmark calculation to work properly. While working on this, I implemented a couple of functions (see `src/group_tools/basis.py`) that might be helpful to switch between the old and the new representation:

- `convert_to_old` converts dictionary with the new basis set format into the old one 
- `map_to_lists` and `lists_to_map` allow to switch between representations  used before or after the `v.2.0.0` change of format. These functions are general and can be used for other groups (e.g. `ecp`).

