### PR TITLE
keeping the full label of elements (including numbers) in the molecul…

### DIFF
--- a/src/converters/convert_from.py
+++ b/src/converters/convert_from.py
@@ -76,10 +76,8 @@ def run_resultsFile(trexio_file, filename, motype=None):
     trexio.write_nucleus_coord(trexio_file, coord)
     # nucleus_charge will be written later after removing core electrons with ECP
 
-    # Transform H1 into H
-    import re
-    p = re.compile(r'(\d*)$')
-    label = [p.sub("", x.name).capitalize() for x in res.geometry]
+    # Write the element labels as they appear
+    label = [x.name.capitalize() for x in res.geometry]
     trexio.write_nucleus_label(trexio_file, label)
 
     trexio.write_nucleus_point_group(trexio_file, res.point_group)


### PR DESCRIPTION
Removing the numbers from atom labels loses information. If there are two types of the basis for the same type of elements, we generally distinguish them with (say H1, H2). The element can be uniquely identified by its charge but not by its label.

So it is necessary to keep the numbers after element symbols. 

