### PR TITLE
Pyscf to trexio converter via `convert-from`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,10 @@ jobs:
       - name: run tests
         run: |
           # benchmark the converters from external codes
-          trexio convert-from -t gaussian  -i data/chbrclf.log    -b hdf5  trexio_gaussi.h5
-          trexio convert-from -t gamess    -i data/GAMESS_CAS.log -b hdf5  trexio_gamess.h5
+          trexio convert-from -t gaussian  -i data/chbrclf.log          -b hdf5  trexio_gaussi.h5
+          trexio convert-from -t gamess    -i data/GAMESS_CAS.log       -b hdf5  trexio_gamess.h5
+          trexio convert-from -t pyscf     -i data/water.chk            -b hdf5  trexio_pyscfw.h5
+          trexio convert-from -t pyscf     -i data/diamond_single_k.chk -b hdf5  trexio_pyscfd.h5
           # benchmark the MOs by computing numerically integrals on a grid and comparing with the ref values from the file
           trexio check-mos -n 50 trexio_gamess.h5 > mos-res
           grep "Norm of the error" < mos-res | grep -Eo "([0-9]+\.[0-9]*|\.?[0-9]+)([eE][+-][0-9]+)?" > error-res

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.dir/
 *.h5
 
+kp_info.dat
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -12,27 +12,27 @@ Set of tools for TREXIO files.
 - numpy (>=1.17.3)
 - resultsFile [for GAMESS/GAU$$IAN conversion]
 - docopt [for CLI]
+- pyscf [only if you use the pyscf->trexio converter]
 
 
 ## Installation
 
-0. Clone the repository
+### Installation via PyPI, periodically updated
+
+`pip install trexio-tools` 
+
+### Installation from source code
+
+1. Clone the repository
 - `git clone https://github.com/TREX-CoE/trexio_tools.git`
-1. Create an isolated virtual environment, for example using
+2. Create an isolated virtual environment, for example using
 - `python3 -m venv trexio_tools`
-2. Activate the previously created environment, for example using
+3. Activate the previously created environment, for example using
 - `source trexio_tools/bin/activate`
-3. Install/upgrade the Python setup tools
-- `pip install --upgrade setuptools wheel build`
 4. Install the Python packages that are required for `trexio-tools` to work
 - `pip install -r requirements.txt`
-5. Install the `trexio-tools` package using one of the following methods:
-- `pip install trexio-tools` (installation from PyPI, periodically updated)
-- `pip install .` (installation from source, always contains recent updates)
-
-Only the last step has to be repeated to upgrade the `trexio-tools` package.
-This means that the virtual environment can stay the same, unless there have been
-critical updates in `trexio` or `resultsFile` packages.
+5. Install `trexio-tools` via `pip` (also works in `--editable` mode)
+- `pip install .` 
 
 
 ## Instructions for users

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
 trexio>=1.2.0
 resultsFile>=2.4
 docopt
+
+# NOTE: only install pyscf if you use the pyscf->trexio converter !
+# It is quite a heavy package with a lot of functionalities which
+# you may not need
+
+pyscf

--- a/src/converters/convert_from.py
+++ b/src/converters/convert_from.py
@@ -751,8 +751,16 @@ def run_molden(trexio_file, filename, normalized_basis=True, multiplicity=None, 
 
 def run(trexio_filename, filename, filetype, back_end, motype=None):
 
-    if os.path.exists(filename):
-        os.system("rm -rf -- "+trexio_filename)
+    if os.path.exists(trexio_filename):
+        print(f"TREXIO file {trexio_filename} already exists and will be removed.")
+        if back_end == trexio.TREXIO_HDF5:
+            os.system(f"rm -f -- {trexio_filename}")
+        else:
+            if '*' in trexio_filename:
+                raise ValueError(
+                    f"TREXIO file name {trexio_filename} contains * character. Are you sure you want to remove it?"
+                    )
+            os.system(f"rm -rf -- {trexio_filename}")
 
     trexio_file = trexio.File(trexio_filename, mode='w', back_end=back_end)
 
@@ -764,7 +772,8 @@ def run(trexio_filename, filename, filetype, back_end, motype=None):
         trexio_file.close()
         run_pyscf(trexio_filename=trexio_filename, pyscf_checkfile=filename)
     elif filetype.lower() == "fcidump":
-        run_fcidump(trexio_file, filename)
+        raise NotImplementedError(f"Conversion from {filetype} to TREXIO is not supported.")
+        #run_fcidump(trexio_file, filename)
     elif filetype.lower() == "molden":
         run_molden(trexio_file, filename)
     else:

--- a/src/converters/convert_from.py
+++ b/src/converters/convert_from.py
@@ -751,7 +751,7 @@ def run_molden(trexio_file, filename, normalized_basis=True, multiplicity=None, 
 def run(trexio_filename, filename, filetype, back_end, motype=None):
 
     if os.path.exists(trexio_filename):
-        print(f"TREXIO file {trexio_filename} already exists and will be removed.")
+        print(f"TREXIO file {trexio_filename} already exists and will be removed before conversion.")
         if back_end == trexio.TREXIO_HDF5:
             os.remove(trexio_filename)
         else:

--- a/src/converters/convert_from.py
+++ b/src/converters/convert_from.py
@@ -7,8 +7,7 @@ import os
 from group_tools import basis as trexio_basis
 from group_tools import determinant as trexio_det
 
-from . import pyscf_to_trexio as p2t
-from p2t import pyscf_to_trexio as run_pyscf
+from .pyscf_to_trexio import pyscf_to_trexio as run_pyscf
 
 try:
     import trexio
@@ -754,23 +753,20 @@ def run(trexio_filename, filename, filetype, back_end, motype=None):
     if os.path.exists(trexio_filename):
         print(f"TREXIO file {trexio_filename} already exists and will be removed.")
         if back_end == trexio.TREXIO_HDF5:
-            os.system(f"rm -f -- {trexio_filename}")
+            os.remove(trexio_filename)
         else:
-            if '*' in trexio_filename:
-                raise ValueError(
-                    f"TREXIO file name {trexio_filename} contains * character. Are you sure you want to remove it?"
-                    )
-            os.system(f"rm -rf -- {trexio_filename}")
+            raise NotImplementedError(f"Please remove the {trexio_filename} directory manually.")
 
-    trexio_file = trexio.File(trexio_filename, mode='w', back_end=back_end)
+    if "pyscf" not in filetype.lower():
+        trexio_file = trexio.File(trexio_filename, mode='w', back_end=back_end)
 
     if filetype.lower() == "gaussian":
         run_resultsFile(trexio_file, filename, motype)
     elif filetype.lower() == "gamess":
         run_resultsFile(trexio_file, filename, motype)
     elif filetype.lower() == "pyscf":
-        trexio_file.close()
-        run_pyscf(trexio_filename=trexio_filename, pyscf_checkfile=filename)
+        back_end_str = "text" if back_end==trexio.TREXIO_TEXT else "hdf5"
+        run_pyscf(trexio_filename=trexio_filename, pyscf_checkfile=filename, back_end=back_end_str)
     elif filetype.lower() == "fcidump":
         raise NotImplementedError(f"Conversion from {filetype} to TREXIO is not supported.")
         #run_fcidump(trexio_file, filename)

--- a/src/converters/convert_from.py
+++ b/src/converters/convert_from.py
@@ -7,6 +7,9 @@ import os
 from group_tools import basis as trexio_basis
 from group_tools import determinant as trexio_det
 
+from . import pyscf_to_trexio as p2t
+from p2t import pyscf_to_trexio as run_pyscf
+
 try:
     import trexio
 except ImportError as exc:
@@ -745,20 +748,24 @@ def run_molden(trexio_file, filename, normalized_basis=True, multiplicity=None, 
     trexio.write_mo_symmetry(trexio_file, sym)
     trexio.write_mo_coefficient(trexio_file, MoMatrix)
 
+
 def run(trexio_filename, filename, filetype, back_end, motype=None):
 
     if os.path.exists(filename):
         os.system("rm -rf -- "+trexio_filename)
 
-    trexio_file = trexio.File(trexio_filename,mode='w',back_end=back_end)
+    trexio_file = trexio.File(trexio_filename, mode='w', back_end=back_end)
 
     if filetype.lower() == "gaussian":
         run_resultsFile(trexio_file, filename, motype)
     elif filetype.lower() == "gamess":
         run_resultsFile(trexio_file, filename, motype)
+    elif filetype.lower() == "pyscf":
+        trexio_file.close()
+        run_pyscf(trexio_filename=trexio_filename, pyscf_checkfile=filename)
     elif filetype.lower() == "fcidump":
         run_fcidump(trexio_file, filename)
     elif filetype.lower() == "molden":
         run_molden(trexio_file, filename)
     else:
-        raise TypeError("Unknown file type")
+        raise NotImplementedError(f"Conversion from {filetype} to TREXIO is not supported.")

--- a/src/converters/convert_to.py
+++ b/src/converters/convert_to.py
@@ -327,8 +327,6 @@ def run_spherical(t, filename):
     return
 
 
-
-
 def run(trexio_filename, filename, filetype):
 
     try:
@@ -344,12 +342,8 @@ def run(trexio_filename, filename, filetype):
         run_spherical(trexio_file, filename)
 #    elif filetype.lower() == "normalized_aos":
 #        run_normalized_aos(trexio_file, filename)
-#    elif filetype.lower() == "gamess":
-#        run_resultsFile(trexio_file, filename)
 #    elif filetype.lower() == "fcidump":
 #        run_fcidump(trexio_file, filename)
-#    elif filetype.lower() == "molden":
-#        run_fcidump(trexio_file, filename)
     else:
-        raise TypeError("Unknown file type")
+        raise NotImplementedError(f"Conversion from TREXIO to {filetype} is not supported.")
 

--- a/src/converters/pyscf_to_trexio.py
+++ b/src/converters/pyscf_to_trexio.py
@@ -3,17 +3,8 @@
 # maintainer: Kosuke Nakano
 # email: "kousuke_1123@icloud.com"
 
-# load python packages
-import os
-import numpy as np
-
-# load pyscf packages
-from pyscf import scf
-from pyscf.pbc import scf as pbcscf
-
 # Logger
 from logging import getLogger
-
 logger = getLogger("pyscf-trexio").getChild(__name__)
 
 def pyscf_to_trexio(
@@ -22,6 +13,15 @@ def pyscf_to_trexio(
     twist_average_in: bool = False,
     force_wf_complex: bool = False,
 ):
+"""PySCF to TREXIO converter."""
+
+    # load python packages
+    import os
+    import numpy as np
+    # load pyscf packages
+    from pyscf import scf
+    from pyscf.pbc import scf as pbcscf
+
     # ## pySCF -> TREX-IO
     # - how to install trexio
     # - pip install trexio

--- a/src/converters/pyscf_to_trexio.py
+++ b/src/converters/pyscf_to_trexio.py
@@ -182,7 +182,7 @@ def pyscf_to_trexio(
         # for p -> px, py, pz
         # for l >= d -> m=(-l ... 0 ... +l)
 
-        basis_type = "G"  # thanks anthony!
+        basis_type = "Gaussian"  # thanks anthony!
         basis_shell_num = int(np.sum([mol.atom_nshells(i) for i in range(nucleus_num)]))
         nucleus_index = []
         for i in range(nucleus_num):
@@ -679,6 +679,7 @@ def cli():
     pyscf_to_trexio(
         pyscf_checkfile=args.pyscf_checkfile,
         trexio_filename=args.trexio_filename,
+        back_end=args.back_end
     )
 
 

--- a/src/converters/pyscf_to_trexio.py
+++ b/src/converters/pyscf_to_trexio.py
@@ -7,13 +7,15 @@
 from logging import getLogger
 logger = getLogger("pyscf-trexio").getChild(__name__)
 
+
 def pyscf_to_trexio(
     pyscf_checkfile: str = "pyscf.chk",
     trexio_filename: str = "trexio.hdf5",
     twist_average_in: bool = False,
     force_wf_complex: bool = False,
+    back_end: str = "hdf5"
 ):
-"""PySCF to TREXIO converter."""
+    """PySCF to TREXIO converter."""
 
     # load python packages
     import os
@@ -109,11 +111,19 @@ def pyscf_to_trexio(
         else:
             filename = trexio_filename
 
-        if os.path.exists(filename):
+        if os.path.exists(filename) and back_end.lower() == "hdf5":
             os.remove(filename)
 
+        # trexio back end handling
+        if back_end.lower() == "hdf5":
+            trexio_back_end = trexio.TREXIO_HDF5
+        elif back_end.lower() == "text":
+            trexio_back_end = trexio.TREXIO_TEXT
+        else:
+            raise NotImplementedError(f"{back_end} back-end is not supported.")
+
         # trexio file
-        trexio_file = trexio.File(filename, mode="w", back_end=trexio.TREXIO_HDF5)
+        trexio_file = trexio.File(filename, mode="w", back_end=trexio_back_end)
 
         ##########################################
         # PBC info
@@ -653,6 +663,13 @@ def cli():
         help="trexio filename",
         type=str,
         default="trexio.hdf5",
+    )
+    parser.add_argument(
+        "-b",
+        "--back_end",
+        help="trexio I/O back-end",
+        type=str,
+        default="hdf5",
     )
 
     # parse the input values

--- a/src/converters/pyscf_to_trexio.py
+++ b/src/converters/pyscf_to_trexio.py
@@ -63,9 +63,9 @@ def pyscf_to_trexio(
         except KeyError:
             twist_average = True
             logger.info("Twisted-average calculation")
-            logger.info("Separated TREXIO files are generated")
+            logger.info("Separate TREXIO files are generated")
             logger.info(
-                "The Correspondence between the index \
+                "The correspondence between the index \
                     and k is written in kp_info.dat"
             )
             logger.info("The generated WFs will be complex.")
@@ -87,15 +87,15 @@ def pyscf_to_trexio(
     if pbc_flag:
         if len(mol._pseudo) > 0:
             logger.error(
-                "TREXIO does not support 'pseudo' format for PBC. Plz. use 'ecp'"
+                "TREXIO does not support 'pseudo' format for PBC. Use 'ecp'."
             )
             raise NotImplementedError
 
     if twist_average:
         logger.warning(
-            f"WF at each k point is saved as a separated file, kXXXX_{trexio_filename}"
+            f"WF at each k point is saved in a separate file kXXXX_{trexio_filename}"
         )
-        logger.warning("k points info. is stored in kp_info.dat.")
+        logger.warning("k points information is stored in kp_info.dat file.")
 
     # each k WF is stored as a separate file!!
     # for an open-boundary calculation, and a single-k one,
@@ -115,8 +115,12 @@ def pyscf_to_trexio(
         else:
             filename = trexio_filename
 
-        if os.path.exists(filename) and back_end.lower() == "hdf5":
-            os.remove(filename)
+        if os.path.exists(filename):
+            logger.warning(f"TREXIO file {filename} already exists and will be removed before conversion.")
+            if back_end.lower() == "hdf5":
+                os.remove(filename)
+            else:
+                raise NotImplementedError(f"Please remove the {filename} directory manually.")
 
         # trexio back end handling
         if back_end.lower() == "hdf5":

--- a/src/trexio_tools/trexio_run.py
+++ b/src/trexio_tools/trexio_run.py
@@ -19,7 +19,7 @@ Options:
       -s, --back_end_from=BACK_END  [hdf5 | text | auto]  The input TREXIO back end.  [default: auto]
       -j, --json=TREX_JSON_FILE     TREX configuration file (in JSON format).
       -w, --overwrite=OVERWRITE     Overwrite flag for the conversion of back ends.  [default: True]
-      -t, --type=TYPE               [gaussian | gamess | fcidump | molden | cartesian ] File format.
+      -t, --type=TYPE               [gaussian | gamess | pyscf | fcidump | molden | cartesian ] File format.
       -x, --motype=MO_TYPE          [natural | initial | guga-initial | guga-natural] The type of the molecular orbitals.
 """
 


### PR DESCRIPTION
Integration of @kousuke-nakano 's converter into the driver script via `convert-from`.

In the meantime I improved error handling for the non-supported cases by raising `NotImplementedError`.

@kousuke-nakano I have one question:
I managed to convert two of your examples (from the `data` folder): `water.chk` and `diamond_single_k.chk`. However, for the multiple k points I get the following error:

```
  File "/home/q-posev/trexio_tools/src/converters/convert_from.py", line 769, in run
    run_pyscf(trexio_filename=trexio_filename, pyscf_checkfile=filename, back_end=back_end_str)
  File "/home/q-posev/trexio_tools/src/converters/pyscf_to_trexio.py", line 78, in pyscf_to_trexio
    assert twist_average_in == twist_average
AssertionError
```

Line for reproducing the error:
`trexio convert-from -t pyscf -i data/diamond_k_grid.chk trexio_k_grid.h5`

Is it expected behavior? From what I see in the script the `twist_average_in` is not used anywhere else. Should I remove it together with the assertion?
