### PR TITLE
changes to read cell matrix pysc2trexio periodic systems

### DIFF
--- a/src/trexio_tools/converters/pyscf_to_trexio.py
+++ b/src/trexio_tools/converters/pyscf_to_trexio.py
@@ -138,9 +138,14 @@ def pyscf_to_trexio(
         ##########################################
         if pbc_flag:
             Bohr = 0.5291772109
-            a = np.array(mol.a[0]) / Bohr  # angstrom -> bohr
-            b = np.array(mol.a[1]) / Bohr  # angstrom -> bohr
-            c = np.array(mol.a[2]) / Bohr  # angstrom -> bohr
+            #a = np.array(mol.a[0]) / Bohr  # angstrom -> bohr
+            #b = np.array(mol.a[1]) / Bohr  # angstrom -> bohr
+            #c = np.array(mol.a[2]) / Bohr  # angstrom -> bohr
+            hmatrix=np.fromstring(mol.a, dtype=np.float64, sep=' ').reshape((3,3),order='C')
+            a=np.array(hmatrix[0,:])/ Bohr  # angstrom -> bohr
+            b=np.array(hmatrix[1,:])/ Bohr  # angstrom -> bohr
+            c=np.array(hmatrix[2,:])/ Bohr  # angstrom -> bohr
+
             k_point = k_vec
             periodic = True
         else:

--- a/src/trexio_tools/converters/pyscf_to_trexio.py
+++ b/src/trexio_tools/converters/pyscf_to_trexio.py
@@ -138,13 +138,15 @@ def pyscf_to_trexio(
         ##########################################
         if pbc_flag:
             Bohr = 0.5291772109
-            #a = np.array(mol.a[0]) / Bohr  # angstrom -> bohr
-            #b = np.array(mol.a[1]) / Bohr  # angstrom -> bohr
-            #c = np.array(mol.a[2]) / Bohr  # angstrom -> bohr
-            hmatrix=np.fromstring(mol.a, dtype=np.float64, sep=' ').reshape((3,3),order='C')
-            a=np.array(hmatrix[0,:])/ Bohr  # angstrom -> bohr
-            b=np.array(hmatrix[1,:])/ Bohr  # angstrom -> bohr
-            c=np.array(hmatrix[2,:])/ Bohr  # angstrom -> bohr
+            if isinstance(mol.a, list):
+                a = np.array(mol.a[0]) / Bohr  # angstrom -> bohr
+                b = np.array(mol.a[1]) / Bohr  # angstrom -> bohr
+                c = np.array(mol.a[2]) / Bohr  # angstrom -> bohr
+            else:
+                hmatrix=np.fromstring(mol.a, dtype=np.float64, sep=' ').reshape((3,3),order='C')
+                a=np.array(hmatrix[0,:])/ Bohr  # angstrom -> bohr
+                b=np.array(hmatrix[1,:])/ Bohr  # angstrom -> bohr
+                c=np.array(hmatrix[2,:])/ Bohr  # angstrom -> bohr
 
             k_point = k_vec
             periodic = True


### PR DESCRIPTION
Hi, 

I found a problem long time ago when using the converter from pyscf to trexio for periodic systems. I just forget to do the request always.   It happens when reading the cell matrix sometimes seems to be just a string and it is not converted properly to a numpy array. The error message is like this: 

error:" TypeError: ufunc 'divide' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe'' "

 I solved in a simple  way  with the modifications on this fork. I don't think it generates any conflict or other problem. I would like to ask to  @kousuke-nakano or  @q-posev to review it before merged if you regard it appropriate.

best, 

Edgar 