### PR TITLE
fix mo_coeff dimensions

### DIFF
--- a/src/trexio_tools/converters/pyscf_to_trexio.py
+++ b/src/trexio_tools/converters/pyscf_to_trexio.py
@@ -304,7 +304,8 @@ def pyscf_to_trexio(
                 mo_energy = mo_energy_read[ns]
                 mo_coeff = mo_coeff_read[ns]
 
-            mo_num = len(mo_coeff)
+            mo_num = len(mo_coeff[0])
+            
             mo_spin_all += [spin for _ in range(mo_num)]
 
             # mo reordering because mo_coeff[:,mo_i]!!


### PR DESCRIPTION
Hi @q-posev and @kousuke-nakano, 

I found a bug while doing a convergence test to the basis set limit. The pyscf2trexio converter is assuming the  mo_num=ao_num. Which in general is not the case, I observed this for a cc-pvQz basis since was necessary to remove some of the orbitals because linear convergence orbitals to compute the RHF calculation. 

Attached the check file. I did some testing in my workflow and it seems to be working. I hope I didn't miss something else.  I will wait for the tests and your review. 
best, 

Edgar  

[RHF-qz.dump.zip](https://github.com/TREX-CoE/trexio_tools/files/11906249/RHF-qz.dump.zip)

