### PR TITLE
Crystal to TREXIO converter via CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           trexio convert-from -t pyscf     -i data/water.chk            -b hdf5  trexio_pyscf_h2o_sph.h5
           trexio convert-from -t pyscf     -i data/diamond_single_k.chk -b hdf5  trexio_pyscf_1k.h5
           trexio convert-from -t pyscf     -i data/diamond_k_grid.chk   -b hdf5  trexio_pyscf_Nk.h5
-          trexio convert-from -t crystal   -i crystal23_mgo_lda.out -m 1 -b hdf5 crystal.hdf5 
+          trexio convert-from -t crystal   -i data/crystal23_mgo_lda.out -m 1 -b hdf5 crystal.hdf5 
           trexio convert-from -t orca      -i data/h2o.json             -b hdf5  trexio_orca_h2o_sph.h5
           trexio convert-to -t cartesian -o trexio_orca_h2o.h5 trexio_orca_h2o_sph.h5
           trexio convert-to -t cartesian -o trexio_pyscf_h2o.h5 trexio_pyscf_h2o_sph.h5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
           trexio convert-from -t pyscf     -i data/water.chk            -b hdf5  trexio_pyscf_h2o_sph.h5
           trexio convert-from -t pyscf     -i data/diamond_single_k.chk -b hdf5  trexio_pyscf_1k.h5
           trexio convert-from -t pyscf     -i data/diamond_k_grid.chk   -b hdf5  trexio_pyscf_Nk.h5
+          trexio convert-from -t crystal   -i crystal23_mgo_lda.out -m 1 -b hdf5 crystal.hdf5 
           trexio convert-from -t orca      -i data/h2o.json             -b hdf5  trexio_orca_h2o_sph.h5
           trexio convert-to -t cartesian -o trexio_orca_h2o.h5 trexio_orca_h2o_sph.h5
           trexio convert-to -t cartesian -o trexio_pyscf_h2o.h5 trexio_pyscf_h2o_sph.h5

--- a/src/trexio_tools/converters/convert_from.py
+++ b/src/trexio_tools/converters/convert_from.py
@@ -9,6 +9,7 @@ from trexio_tools.group_tools import determinant as trexio_det
 
 from .pyscf_to_trexio import pyscf_to_trexio as run_pyscf
 from .orca_to_trexio import orca_to_trexio as run_orca
+from .crystal_to_trexio import crystal_to_trexio as run_crystal
 
 try:
     import trexio
@@ -201,9 +202,6 @@ def run_resultsFile(trexio_file, filename, motype=None):
     trexio.write_basis_coefficient(trexio_file,coefficient)
     trexio.write_basis_prim_factor(trexio_file,prim_factor)
 
-    # For Gaussian basis sets, basis_r_power is zero
-    basis_r_power = [0.0 for _ in range(shell_num) ]
-    trexio.write_basis_r_power(trexio_file,basis_r_power)
 
     # AO
     # --
@@ -653,10 +651,6 @@ def run_molden(trexio_file, filename, normalized_basis=True, multiplicity=None, 
     # write normalization factor for each shell
     trexio.write_basis_shell_factor(trexio_file,shell_factor)
 
-    # For Gaussian basis sets, basis_r_power is zero
-    basis_r_power = [0.0 for _ in range(basis_shell_num) ]
-    trexio.write_basis_r_power(trexio_file,basis_r_power)
-
     # write parameters of the primitives
     trexio.write_basis_exponent(trexio_file,exponent)
     trexio.write_basis_coefficient(trexio_file,coefficient)
@@ -756,7 +750,7 @@ def run_molden(trexio_file, filename, normalized_basis=True, multiplicity=None, 
     trexio.write_mo_coefficient(trexio_file, MoMatrix)
 
 
-def run(trexio_filename, filename, filetype, back_end, motype=None):
+def run(trexio_filename, filename, filetype, back_end, spin=None, motype=None):
 
     if os.path.exists(trexio_filename):
         print(f"TREXIO file {trexio_filename} already exists and will be removed before conversion.")
@@ -778,9 +772,10 @@ def run(trexio_filename, filename, filetype, back_end, motype=None):
     elif filetype.lower() == "orca":
         back_end_str = "text" if back_end==trexio.TREXIO_TEXT else "hdf5"
         run_orca(filename=trexio_filename, orca_json=filename, back_end=back_end_str)
-    elif filetype.lower() == "fcidump":
-        raise NotImplementedError(f"Conversion from {filetype} to TREXIO is not supported.")
-        #run_fcidump(trexio_file, filename)
+    elif filetype.lower() == "crystal":
+        if spin is None: raise ValueError("You forgot to provide spin for the CRYSTAL->TREXIO converter.")
+        back_end_str = "text" if back_end==trexio.TREXIO_TEXT else "hdf5"
+        run_crystal(trexio_filename=trexio_filename, crystal_output=filename, back_end=back_end_str, spin=spin)
     elif filetype.lower() == "molden":
         run_molden(trexio_file, filename)
     else:

--- a/src/trexio_tools/converters/convert_from.py
+++ b/src/trexio_tools/converters/convert_from.py
@@ -202,6 +202,9 @@ def run_resultsFile(trexio_file, filename, motype=None):
     trexio.write_basis_coefficient(trexio_file,coefficient)
     trexio.write_basis_prim_factor(trexio_file,prim_factor)
 
+    # For Gaussian basis sets, basis_r_power is zero
+    basis_r_power = [0.0 for _ in range(shell_num) ]
+    trexio.write_basis_r_power(trexio_file,basis_r_power)
 
     # AO
     # --
@@ -650,6 +653,10 @@ def run_molden(trexio_file, filename, normalized_basis=True, multiplicity=None, 
 
     # write normalization factor for each shell
     trexio.write_basis_shell_factor(trexio_file,shell_factor)
+
+    # For Gaussian basis sets, basis_r_power is zero
+    basis_r_power = [0.0 for _ in range(basis_shell_num) ]
+    trexio.write_basis_r_power(trexio_file,basis_r_power)
 
     # write parameters of the primitives
     trexio.write_basis_exponent(trexio_file,exponent)

--- a/src/trexio_tools/trexio_run.py
+++ b/src/trexio_tools/trexio_run.py
@@ -6,7 +6,7 @@ Usage:
       trexio check-basis      [-n N_POINTS]  [-b BACK_END]  TREXIO_FILE
       trexio check-mos        [-n N_POINTS]  [-b BACK_END]  TREXIO_FILE
       trexio convert-to       -t TYPE -o OUTPUT_FILE [-y SPIN_ORDER]  TREXIO_FILE
-      trexio convert-from     -t TYPE -i INPUT_FILE  [-b BACK_END]  [-x MO_TYPE]  TREXIO_FILE
+      trexio convert-from     -t TYPE -i INPUT_FILE  [-b BACK_END]  [-x MO_TYPE]  [-m MULTIPLICITY]  TREXIO_FILE
       trexio convert-backend  -i INPUT_FILE  -o OUTPUT_FILE  -b BACK_END  -j TREX_JSON_FILE  [-s BACK_END_FROM]  [-w OVERWRITE]
       trexio (-h | --help)
 
@@ -17,9 +17,10 @@ Options:
       -o, --output=OUTPUT_FILE      Name of the output file.
       -b, --back_end=BACK_END       [hdf5 | text | auto]  The TREXIO back end.  [default: hdf5]
       -s, --back_end_from=BACK_END  [hdf5 | text | auto]  The input TREXIO back end.  [default: auto]
+      -m, --multiplicity=MULTIPLICITY  Spin multiplicity for the Crystal converter.
       -j, --json=TREX_JSON_FILE     TREX configuration file (in JSON format).
       -w, --overwrite=OVERWRITE     Overwrite flag for the conversion of back ends.  [default: True]
-      -t, --type=TYPE               [gaussian | gamess | pyscf | orca | fcidump | molden | cartesian ] File format.
+      -t, --type=TYPE               [gaussian | gamess | pyscf | orca | crystal | fcidump | molden | cartesian ] File format.
       -x, --motype=MO_TYPE          Type of the molecular orbitals. For example, GAMESS has RHF, MCSCF, GUGA, and Natural as possible MO types.
       -y, --spin_order=TYPE         [block | interleave] How to organize spin orbitals when converting to FCIDUMP [default: block]
 """
@@ -73,6 +74,9 @@ def main(filename=None, args=None):
     else:
         back_end_from = trexio.TREXIO_AUTO
 
+    spin = None
+    if args["--multiplicity"]:
+        spin = int(args["--multiplicity"])
 
     if args["check-basis"]:
         trexio_file = trexio.File(filename, 'r', back_end=back_end)
@@ -92,7 +96,7 @@ def main(filename=None, args=None):
 
     elif args["convert-from"]:
         from .converters.convert_from import run
-        run(args["TREXIO_FILE"], args["--input"], args["--type"], back_end=back_end, motype=args["--motype"])
+        run(args["TREXIO_FILE"], args["--input"], args["--type"], back_end=back_end, spin=spin, motype=args["--motype"])
 
     elif args["convert-to"]:
         from .converters.convert_to import run


### PR DESCRIPTION
@kousuke-nakano this PR is a follow-up of your PR #36.

I just added `crystal` as an option to `trexio convert-from` CLI.

You can test it as follows:

`trexio convert-from -t crystal   -i data/crystal23_mgo_lda.out -m 1 -b hdf5 crystal.hdf5`

On a separate note, when I executed this line locally and checked the `k0_crystal.hdf5` TREXIO file, some `basis_prim_factor` values were really weird, like for example with `e-321` multiplier. I guess there might be a bug somewhere in your converter.
 