### PR TITLE
Improve force overwriting for existing output files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,9 @@ jobs:
           trexio convert-to -t cartesian -o trexio_orca_h2o.h5 trexio_orca_h2o_sph.h5
           trexio convert-to -t cartesian -o trexio_pyscf_h2o.h5 trexio_pyscf_h2o_sph.h5
           echo "==  Done conversion  =="
+          # dummy checks for overwriting
+          trexio convert-from -t gaussian  -i data/chbrclf.log -b hdf5  trexio_gaussi.h5 || echo "Failure as it should"
+          trexio convert-from -t gaussian  -i data/chbrclf.log -b hdf5 -w True  trexio_gaussi.h5 && echo "Success as it should"
           echo "=== Check TREXIO file converted from GAMESS ==="
           trexio check-mos -n 50 trexio_gamess.h5 > mos-res
           grep "Norm of the error" < mos-res | grep -Eo "([0-9]+\.[0-9]*|\.?[0-9]+)([eE][+-][0-9]+)?" > error-res

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           trexio convert-to -t cartesian -o trexio_pyscf_h2o.h5 trexio_pyscf_h2o_sph.h5
           echo "==  Done conversion  =="
           # dummy checks for overwriting
-          trexio convert-from -t gaussian  -i data/chbrclf.log -b hdf5  trexio_gaussi.h5 || echo "Failure as it should"
+          trexio convert-from -t gaussian  -i data/chbrclf.log -b hdf5 -w False trexio_gaussi.h5 || echo "Failure as it should"
           trexio convert-from -t gaussian  -i data/chbrclf.log -b hdf5 -w True  trexio_gaussi.h5 && echo "Success as it should"
           echo "=== Check TREXIO file converted from GAMESS ==="
           trexio check-mos -n 50 trexio_gamess.h5 > mos-res

--- a/src/trexio_tools/converters/convert_back_end.py
+++ b/src/trexio_tools/converters/convert_back_end.py
@@ -88,10 +88,7 @@ def run_converter(filename_from, filename_to, back_end_to, back_end_from=None, o
     """The high-level converter function."""
 
     import os
-    try:
-        import trexio
-    except ImportError as exc:
-        raise ImportError("trexio Python package is not installed.") from exc
+    import trexio
 
     try:
         # For proper python package
@@ -114,6 +111,9 @@ def run_converter(filename_from, filename_to, back_end_to, back_end_from=None, o
                 os.system(f'rm -rf -- {filename_to}')
         else:
             raise ValueError(f'Output file {filename_to} already exists. Consider using the `-w` argument.')
+
+    if back_end_from is None:
+        back_end_from = trexio.TREXIO_AUTO
 
     with trexio.File(filename_from, 'r', back_end_from) as trexio_file_from:
         with trexio.File(filename_to, 'w', back_end_to) as trexio_file_to:

--- a/src/trexio_tools/converters/convert_from.py
+++ b/src/trexio_tools/converters/convert_from.py
@@ -11,10 +11,7 @@ from .pyscf_to_trexio import pyscf_to_trexio as run_pyscf
 from .orca_to_trexio import orca_to_trexio as run_orca
 from .crystal_to_trexio import crystal_to_trexio as run_crystal
 
-try:
-    import trexio
-except ImportError as exc:
-    raise ImportError("trexio Python package is not installed.") from exc
+import trexio
 
 try:
     from resultsFile import getFile, a0, get_lm

--- a/src/trexio_tools/converters/convert_from.py
+++ b/src/trexio_tools/converters/convert_from.py
@@ -759,13 +759,6 @@ def run_molden(trexio_file, filename, normalized_basis=True, multiplicity=None, 
 
 def run(trexio_filename, filename, filetype, back_end, spin=None, motype=None):
 
-    if os.path.exists(trexio_filename):
-        print(f"TREXIO file {trexio_filename} already exists and will be removed before conversion.")
-        if back_end == trexio.TREXIO_HDF5:
-            os.remove(trexio_filename)
-        else:
-            raise NotImplementedError(f"Please remove the {trexio_filename} directory manually.")
-
     if "pyscf" not in filetype.lower():
         trexio_file = trexio.File(trexio_filename, mode='w', back_end=back_end)
 

--- a/src/trexio_tools/converters/convert_to.py
+++ b/src/trexio_tools/converters/convert_to.py
@@ -9,11 +9,7 @@ from functools import reduce
 from . import cart_sphe as cart_sphe
 import numpy as np
 
-try:
-    import trexio
-except:
-    print("Error: The TREXIO Python library is not installed")
-    sys.exit(1)
+import trexio
 
 """
 Converter from trexio to fcidump
@@ -606,11 +602,8 @@ def run(trexio_filename, filename, filetype, spin_order):
         run_spherical(trexio_file, filename)
 #    elif filetype.lower() == "normalized_aos":
 #        run_normalized_aos(trexio_file, filename)
-#    elif filetype.lower() == "gamess":
-#        run_resultsFile(trexio_file, filename)
     elif filetype.lower() == "fcidump":
         run_fcidump(trexio_file, filename, spin_order)
-#    elif filetype.lower() == "molden":
     else:
         raise NotImplementedError(f"Conversion from TREXIO to {filetype} is not supported.")
 

--- a/src/trexio_tools/converters/orca_to_trexio.py
+++ b/src/trexio_tools/converters/orca_to_trexio.py
@@ -28,12 +28,6 @@ def orca_to_trexio(
     with open(orca_json, 'r') as f:
         data = json.load(f)
 
-    import os
-    try:
-        os.remove(filename)
-    except:
-        print(f"File {filename} does not exist.")
-
     # trexio back end handling
     if back_end.lower() == "hdf5":
         trexio_back_end = trexio.TREXIO_HDF5

--- a/src/trexio_tools/trexio_run.py
+++ b/src/trexio_tools/trexio_run.py
@@ -34,9 +34,20 @@ def remove_trexio_file(filename:str, overwrite:bool) -> None:
     """Remove the TREXIO file/directory if it exists."""
     if os.path.exists(filename):
         if overwrite:
+            # dummy check
             if '*' in filename:
                 raise ValueError(f'TREXIO filename {filename} contains * symbol. Are you sure?')
-            os.system(f'rm -rf -- {filename} ')
+            # check that the file is actually TREXIO file
+            try:
+                is_trexio = False
+                with trexio.File(filename, 'r', trexio.TREXIO_AUTO) as tfile:
+                    if trexio.has_metadata_package_version(tfile):
+                        is_trexio = True
+                        
+                if is_trexio: os.system(f'rm -rf -- {filename}')
+                
+            except:
+                raise Exception(f'Output file {filename} exists but it is not a TREXIO file. Are you sure?')
         else:
             raise Exception(f'Output file {filename} already exists but overwrite option is not provided. Consider using the `-w` CLI argument.')
 


### PR DESCRIPTION
- Fixes #41 

Mainly moved the file removal logic to the high-level `trexio_run.py` script and fixed some inconsistencies. Now it calls `rm -rf` so it should work for both TEXT and HDF5 back ends unlike the previous version that was printing an error message for TEXT TREXIO files. 