### PR TITLE
Fix PySCF->QP2 transformation

### DIFF
--- a/src/trexio_tools/converters/convert_from.py
+++ b/src/trexio_tools/converters/convert_from.py
@@ -51,9 +51,11 @@ def run_resultsFile(trexio_file, filename, motype=None):
     trexio.write_metadata_code_num(trexio_file, 1)
     trexio.write_metadata_code(trexio_file,
                [str(res).split('.')[-1].split()[0].replace("File","")] )
-    trexio.write_metadata_author_num(trexio_file, 1)
-    trexio.write_metadata_author(trexio_file, [res.author])
-    trexio.write_metadata_description(trexio_file, res.title)
+    if res.author is not None:
+        trexio.write_metadata_author_num(trexio_file, 1)
+        trexio.write_metadata_author(trexio_file, [res.author])
+    if res.title is not None:
+        trexio.write_metadata_description(trexio_file, res.title)
 
     # Electrons
     # ---------

--- a/src/trexio_tools/converters/convert_to.py
+++ b/src/trexio_tools/converters/convert_to.py
@@ -438,6 +438,12 @@ def run_cart_phe(inp, filename, to_cartesian):
 
     ao_num_in  = trexio.read_ao_num(inp)
 
+    normalization = np.array( [ 1. ] * ao_num_in )
+    if trexio.has_ao_normalization(inp):
+      normalization = trexio.read_ao_normalization(inp)
+
+    for i,f in enumerate(normalization):
+      cart_normalization[i] *= f
 
     if to_cartesian == 0:
         print("Transformation from cartesian to spherical is not implemented")
@@ -465,10 +471,6 @@ def run_cart_phe(inp, filename, to_cartesian):
     trexio.write_ao_cartesian(out, to_cartesian)
     trexio.write_ao_num(out, ao_num_out)
     trexio.write_ao_shell(out, shell)
-
-    normalization = np.array( [ 1. ] * ao_num_in )
-    if trexio.has_ao_normalization(inp):
-      normalization = trexio.read_ao_normalization(inp)
 
     trexio.write_ao_normalization(out, cart_normalization)
 

--- a/src/trexio_tools/converters/convert_to.py
+++ b/src/trexio_tools/converters/convert_to.py
@@ -497,7 +497,9 @@ def run_cart_phe(inp, filename, to_cartesian):
     mix radial and angular coordinates. Thus, r_power needs to be adapted to cancel
     out the radial dependence of the polynomials.
     """
-    r_power = trexio.read_basis_r_power(inp)
+
+    r_power = [0.0 for _ in shell_ang_mom ]
+
     r_power_sign = -1
     if to_cartesian == 0:
         r_power_sign = +1


### PR DESCRIPTION
This PR should fix all the problems between PySCF and QP2. Most of them came from a normalization factor of spherical orbitals that was nor properly propagated to the cartesian in the conversion.